### PR TITLE
[GIT PULL] CI: Add llvm build test for GitHub action

### DIFF
--- a/.github/workflows/llvm.yaml
+++ b/.github/workflows/llvm.yaml
@@ -1,0 +1,30 @@
+name: LLVM Build Test
+
+on:
+  # Trigger the workflow on push or pull requests.
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+      with:
+          fetch-depth: 1
+          submodules: true
+    - name: Install Compilers
+      run: |
+        sudo apt-get purge -qq --auto-remove llvm python3-lldb-14 llvm-14 -y;
+        wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh;
+        sudo bash /tmp/llvm.sh 18;
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 400;
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 400;
+    - name: Build Linux
+      run: |
+        make CC=clang ENABLE_STATIC=1 -j


### PR DESCRIPTION
Add llvm build test for GitHub action. Test whether it compiles
successfully with clang. Do it every push and PR event.

Please review.

```
The following changes since commit 51e1e453cbc9a3ff022fdee5e5f5a4171ee6806a:

  HevConfig: Bump up to 2.6.2. (2023-10-13 21:55:46 +0800)

are available in the Git repository at:

  https://github.com/ammarfaizi2/hev-socks5-server.git master

for you to fetch changes up to 5659e5535ff7c7d8b0e7e444e52521fbcd3f2248:

  CI: Add llvm build test for GitHub action (2023-10-17 07:01:51 +0700)

----------------------------------------------------------------
Ammar Faizi (1):
      CI: Add llvm build test for GitHub action

 .github/workflows/llvm.yaml | 30 ++++++++++++++++++++++++++++++
 1 file changed, 30 insertions(+)
 create mode 100644 .github/workflows/llvm.yaml

```